### PR TITLE
Execute with -fhir-settings parameter

### DIFF
--- a/images/ig-build/builder/builder.py
+++ b/images/ig-build/builder/builder.py
@@ -67,6 +67,7 @@ def build(config):
          '-jar', '../publisher.jar',
          '-ig', 'ig.json',
          '-api-key-file', '/etc/ig.builder.keyfile.ini',
+         '-fhir-settings', '/etc/fhir-settings.json',
          '-auto-ig-build',
          '-tx', TX_SERVER_URL,
          '-target', 'https://build.fhir.org/ig/%s/%s/'%(details['org'], details['repo']),

--- a/triggers/ig-commit-trigger/job.json
+++ b/triggers/ig-commit-trigger/job.json
@@ -22,6 +22,13 @@
               "secretName": "ci-build-keys",
               "defaultMode": 256
             }
+          },
+          {
+            "name": "fhir-settings",
+            "secret": {
+              "secretName": "fhir-settings",
+              "defaultMode": 256
+            }
           }
         ],
         "containers": [
@@ -37,6 +44,11 @@
               "name": "keys",
               "subPath": "ig.builder.keyfile.ini",
               "mountPath": "/etc/ig.builder.keyfile.ini"
+            },
+            {
+              "name": "fhir-settings",
+              "subPath": "fhir-settings.json",
+              "mountPath": "/etc/fhir-settings.json"
             }],
             "resources": {
               "requests": {


### PR DESCRIPTION
Adds the -fhir-settings parameter to publisher params.

Note, the old param `-api-key-file` can remain, but is no longer used. I confirmed this by running the following locally with the latest publisher:

```shell
java -jar publisher.jar -ig au-fhir-core -api-key-file /etc/ig.builder.keyfile.ini -fhir-settings /Users/me/IN/2023-05-03-test-ig-publisher-fhir-settings/settings-example.json
```