### PR TITLE
ci-build: clean up orphaned per-build upload staging dirs

### DIFF
--- a/images/ci-build/publish
+++ b/images/ci-build/publish
@@ -3,7 +3,10 @@
 set -e
 
 function finish {
-  kill $KEEPALIVE_PID
+  [ -n "$KEEPALIVE_PID" ] && kill "$KEEPALIVE_PID" 2>/dev/null
+  # Clean the staging dir (and any half-rotated .old) if we exited before the final
+  # mv into www/. Guard prevents an unset $TARGET from expanding to ~/uploading.
+  [ -n "$TARGET" ] && rm -rf ~/uploading/"$TARGET" ~/uploading/fhir."$TARGET".old 2>/dev/null
 }
 trap finish EXIT
 

--- a/images/ci-build/publish-ig
+++ b/images/ci-build/publish-ig
@@ -3,7 +3,12 @@
 set -e
 
 function finish_upload_keepalive {
-  kill $KEEPALIVE_PID
+  [ -n "$KEEPALIVE_PID" ] && kill "$KEEPALIVE_PID" 2>/dev/null
+  # If the run failed/was interrupted before the final mv into www/, the staging dir
+  # (and any half-rotated .old) are still here. Remove them so orphaned per-build
+  # dirs don't accumulate at the root of ~/uploading forever. The guard keeps an
+  # unset $TARGET from ever expanding to ~/uploading itself.
+  [ -n "$TARGET" ] && rm -rf ~/uploading/"$TARGET" ~/uploading/branch."$TARGET".old 2>/dev/null
 }
 trap finish_upload_keepalive EXIT
 

--- a/images/ci-build/reindex
+++ b/images/ci-build/reindex
@@ -25,6 +25,27 @@ reindex_files() {
     done
 }
 
+gc_stale_uploads() {
+    # Sweep orphaned per-build staging dirs left at the root of ~/uploading when a
+    # publish/publish-ig run was interrupted before its final mv (Spot preemption,
+    # pod restart, tar/mv failure). Belt-and-suspenders to the EXIT traps in those
+    # scripts. The served site lives under www/ and is never touched; ctime +N keeps
+    # in-flight uploads safe.
+    GC_AFTER_DAYS=${GC_AFTER_DAYS:-2}
+    find ~/uploading -maxdepth 1 -mindepth 1 -type d \
+        ! -name www ! -name 'lost+found' -ctime +"$GC_AFTER_DAYS" \
+        -exec rm -rf {} \; 2>/dev/null || true
+}
+
+maybe_gc() {
+    # Run the sweep at most once per hour, independent of reindex traffic.
+    local marker=~/.last_upload_gc
+    if [ ! -f "$marker" ] || [ $(( $(date +%s) - $(stat -c %Y "$marker") )) -ge 3600 ]; then
+        gc_stale_uploads
+        touch "$marker"
+    fi
+}
+
 process_reindexing() {
     # Get the most recent semaphore file
     cd ~/reindex_queue
@@ -49,5 +70,6 @@ process_reindexing() {
 
 while true; do
     process_reindexing
+    maybe_gc
     sleep 10
 done


### PR DESCRIPTION
## Problem

`publish` / `publish-ig` receive each build into a staging dir
`~/uploading/<RANDOM>[_org_repo]` and only `mv` it into `www/` **on success**. If a
run is interrupted before that final `mv` — Spot preemption of the build node, a
ci-build pod restart, a failed `tar`, or an `mv` error — the staging dir is left
stranded at the root of `~/uploading`, and **nothing ever reclaims it** (the
`reindex` autoclean only operates inside `www/ig`).

In production these have accumulated into **hundreds of dirs / hundreds of GB** on
the ci-build persistent disk (observed ~763 G used, 81% full), dominated by
frequently-built IGs (e.g. many `*_HL7_fhir-sdoh-clinicalcare`). `www/` is the
served site and is fine; everything else at the root of `~/uploading` is orphaned
build cruft.

## Fix

- **`publish` / `publish-ig`** — the `EXIT` trap (which previously only killed the
  keepalive) now also removes the run's own staging dir and any half-rotated `.old`.
  Guarded with `[ -n "$TARGET" ]` so an unset variable can never expand to
  `rm -rf ~/uploading`. It's a no-op on the success path (the dir is already moved).
- **`reindex`** — adds an hourly GC sweep of `~/uploading/*` (excluding `www/` and
  `lost+found`) older than `GC_AFTER_DAYS` (default **2**), as a backstop for runs
  that are `SIGKILL`ed past the trap.

## Safety

- The served site (`www/`) is never touched.
- `-ctime +2` leaves in-flight uploads alone; `-ctime` matches the conventions
  already used by the `reindex` autoclean and `publish` branch-cleanup.
- The `[ -n "$TARGET" ]` guard prevents any `rm -rf ~/uploading` footgun.

## Deploy notes

These scripts are baked into the `ci-build` image, so the fix takes effect after a
**rebuild + redeploy**. On first run the hourly GC will clear the existing backlog
(everything >2 days old) automatically — no manual cleanup required, though the
disk can be reclaimed sooner with a one-off
`find ~/uploading -maxdepth 1 -mindepth 1 -type d ! -name www ! -name 'lost+found' -ctime +2 -exec rm -rf {} \;`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)